### PR TITLE
Add per-game-type bonus score setting (default 50)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
  * @format
  */
 
+import './src/utils/polyfills/backHandler';
+
 import {AppRegistry} from 'react-native';
 import App from './App';
 import {name as appName} from './app.json';

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,4 @@
+import './src/utils/polyfills/backHandler';
 import {NativeModules} from 'react-native';
 
 NativeModules.ImagePickerManager = {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,4 +13,11 @@ jest.mock('react-native-image-crop-picker', () => {
       openCamera: jest.fn().mockImplementation(() => Promise.resolve()),
     };
   });
+
+jest.mock('@sayem314/react-native-keep-awake', () => ({
+    useKeepAwake: jest.fn(),
+    activateKeepAwake: jest.fn(),
+    deactivateKeepAwake: jest.fn(),
+    default: () => null,
+  }));
   

--- a/language/json/en/translation.json
+++ b/language/json/en/translation.json
@@ -55,6 +55,11 @@
       "header": "Choose language",
       "se": "Svenska",
       "en": "English"
+    },
+    "bonusScoreSettings": {
+      "header": "Bonus score",
+      "maxiYatzy": "Maxi Yatzy",
+      "yatzy": "Yatzy"
     }
   }
 }

--- a/language/json/se/translation.json
+++ b/language/json/se/translation.json
@@ -55,6 +55,11 @@
       "header": "Välj språk",
       "se": "Svenska",
       "en": "English"
+    },
+    "bonusScoreSettings": {
+      "header": "Bonuspoäng",
+      "maxiYatzy": "Maxi Yatzy",
+      "yatzy": "Yatzy"
     }
   }
 }

--- a/src/components/settings/bonusScoreSettings.tsx
+++ b/src/components/settings/bonusScoreSettings.tsx
@@ -8,21 +8,19 @@ import styles from './languageSettings.styles';
 
 const DEFAULT_BONUS_SCORE = 50;
 
-interface bonusScoreSettingsProps extends ViewProps { }
-
-type bonusInputProps = {
+type BonusInputProps = Readonly<{
   label: string;
   storage: itemStorage<number>;
   isDarkMode: boolean;
-};
+}>;
 
-function BonusInput({ label, storage, isDarkMode }: bonusInputProps) {
+function BonusInput({ label, storage, isDarkMode }: BonusInputProps) {
   const persisted = storage.get() ?? DEFAULT_BONUS_SCORE;
   const [text, setText] = useState(String(persisted));
   const mStyle = modalStyle(isDarkMode);
 
   const commit = () => {
-    const parsed = parseInt(text, 10);
+    const parsed = Number.parseInt(text, 10);
     if (Number.isFinite(parsed) && parsed >= 0) {
       storage.save(parsed);
       setText(String(parsed));
@@ -53,7 +51,7 @@ function BonusInput({ label, storage, isDarkMode }: bonusInputProps) {
   );
 }
 
-export function BonusScoreSettings(options: bonusScoreSettingsProps) {
+export function BonusScoreSettings(options: Readonly<ViewProps>) {
   const { t } = useTranslation();
   const colorScheme = useColorScheme();
   const isDarkMode = colorScheme === 'dark';

--- a/src/components/settings/bonusScoreSettings.tsx
+++ b/src/components/settings/bonusScoreSettings.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Text, TextInput, useColorScheme, View, ViewProps } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { bonusScoreKey, bonusScoreStorage } from '@helpers/Storage/bonus/bonusScoreStorage';
+import { gameType } from '@helpers/Game/gameType';
+import { modalStyle } from '@styles/sharedStyle';
+import styles from './languageSettings.styles';
+
+const DEFAULT_BONUS_SCORE = 50;
+
+interface bonusScoreSettingsProps extends ViewProps { }
+
+type bonusInputProps = {
+  label: string;
+  storage: itemStorage<number>;
+  isDarkMode: boolean;
+};
+
+function BonusInput({ label, storage, isDarkMode }: bonusInputProps) {
+  const persisted = storage.get() ?? DEFAULT_BONUS_SCORE;
+  const [text, setText] = useState(String(persisted));
+  const mStyle = modalStyle(isDarkMode);
+
+  const commit = () => {
+    const parsed = parseInt(text, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      storage.save(parsed);
+      setText(String(parsed));
+      return;
+    }
+    setText(String(storage.get() ?? DEFAULT_BONUS_SCORE));
+  };
+
+  return (
+    <View style={[mStyle.playerRow, { alignItems: 'center' }]}>
+      <View style={{ flex: 2, paddingLeft: 10 }}>
+        <Text style={[styles.gameNameText, mStyle.modalText, { fontSize: 18, marginBottom: 0, textAlign: 'left' }]}>
+          {label}
+        </Text>
+      </View>
+      <View style={{ flex: 1 }}>
+        <TextInput
+          style={[mStyle.textInput, { width: 80, marginBottom: 0, color: isDarkMode ? '#fff' : '#000' }]}
+          keyboardType="number-pad"
+          maxLength={4}
+          value={text}
+          onChangeText={setText}
+          onEndEditing={commit}
+          onSubmitEditing={commit}
+        />
+      </View>
+    </View>
+  );
+}
+
+export function BonusScoreSettings(options: bonusScoreSettingsProps) {
+  const { t } = useTranslation();
+  const colorScheme = useColorScheme();
+  const isDarkMode = colorScheme === 'dark';
+  const mStyle = modalStyle(isDarkMode);
+
+  const maxiStorage: itemStorage<number> = bonusScoreStorage(bonusScoreKey(gameType.maxiYatzy));
+  const yatzyStorage: itemStorage<number> = bonusScoreStorage(bonusScoreKey(gameType.yatzy));
+
+  return (
+    <View {...options}>
+      <View style={mStyle.playerRow}>
+        <Text style={[styles.gameNameText, { fontSize: 32, padding: 20 }, mStyle.modalText]}>
+          {t('settings.bonusScoreSettings.header')}
+        </Text>
+      </View>
+      <BonusInput
+        label={t('settings.bonusScoreSettings.maxiYatzy')}
+        storage={maxiStorage}
+        isDarkMode={isDarkMode}
+      />
+      <BonusInput
+        label={t('settings.bonusScoreSettings.yatzy')}
+        storage={yatzyStorage}
+        isDarkMode={isDarkMode}
+      />
+    </View>
+  );
+}

--- a/src/components/settings/settingsModal.tsx
+++ b/src/components/settings/settingsModal.tsx
@@ -2,6 +2,7 @@ import { useColorScheme, View } from 'react-native';
 import Modal from 'react-native-modal';
 import { modalStyle } from '@styles/sharedStyle';
 import { LanguageSettings } from '@components/settings/languageSettings';
+import { BonusScoreSettings } from '@components/settings/bonusScoreSettings';
 
 type settingsModalOptions = {
   visible: boolean;
@@ -27,6 +28,7 @@ export function SettingsModal(options: settingsModalOptions) {
         <View style={mStyle.centeredView}>
           <View style={mStyle.modalView}>
             <LanguageSettings />
+            <BonusScoreSettings style={{ marginTop: 20 }} />
           </View>
         </View>
       </Modal>

--- a/src/utils/helpers/Game/__tests__/gameHelper.test.ts
+++ b/src/utils/helpers/Game/__tests__/gameHelper.test.ts
@@ -103,8 +103,8 @@ describe('gameHelper – multiple players', () => {
             // Fill 6 upper rows at max for player A: 6+12+18+24+30+36 = 126 (>= 75).
             [6, 12, 18, 24, 30, 36].forEach((s, i) => setUpper(helper, a.playerId, i, s));
             const playerA = helper.getGame().players?.find(p => p.playerId === a.playerId);
-            // 126 + bonus 100 = 226.
-            expect(playerA?.currentScore).toBe(226);
+            // 126 + bonus 50 = 176.
+            expect(playerA?.currentScore).toBe(176);
         });
 
         it('only the player who reached the limit gets the bonus', () => {
@@ -120,8 +120,8 @@ describe('gameHelper – multiple players', () => {
             [6, 12, 18, 24, 30, 36].forEach((s, i) => setUpper(helper, a.playerId, i, s));
             setMiddle(helper, a.playerId, 0, 12); // pair = 12
             const playerA = helper.getGame().players?.find(p => p.playerId === a.playerId);
-            // 126 (upper) + 100 (bonus) + 12 (middle) = 238
-            expect(playerA?.currentScore).toBe(238);
+            // 126 (upper) + 50 (bonus) + 12 (middle) = 188
+            expect(playerA?.currentScore).toBe(188);
         });
 
         it('getPlayersUpperScore returns each player\'s upper total in player-iteration order', () => {

--- a/src/utils/helpers/Game/gameHelper.ts
+++ b/src/utils/helpers/Game/gameHelper.ts
@@ -10,21 +10,13 @@ import { playerTotalScore } from "./playerTotalScore";
 import { scoreHandler } from "./scoreHandler";
 import { state } from "./state";
 import { TFunction } from "i18next";
+import { bonusScoreKey, bonusScoreStorage } from "@helpers/Storage/bonus/bonusScoreStorage";
+
+const DEFAULT_BONUS_SCORE = 50;
 
 const getBonusScore = (typeOfGame: gameType): number => {
-    let bonusScore: number = 75;
-    switch (typeOfGame) {
-        case gameType.maxiYatzy:
-            bonusScore = 100;
-            break;
-        case gameType.yatzy:
-            bonusScore = 50;
-            break;
-        default:
-            bonusScore = 75;
-            break;
-    }
-    return bonusScore;
+    const stored = bonusScoreStorage(bonusScoreKey(typeOfGame)).get();
+    return stored ?? DEFAULT_BONUS_SCORE;
 }
 
 const getBonusLimit = (typeOfGame: gameType): number => {

--- a/src/utils/helpers/Storage/bonus/bonusScoreStorage.ts
+++ b/src/utils/helpers/Storage/bonus/bonusScoreStorage.ts
@@ -1,0 +1,30 @@
+import { MMKV } from "react-native-mmkv"
+import { gameType } from "@helpers/Game/gameType"
+
+const bonusScoreKey = (typeOfGame: gameType): string => {
+    switch (typeOfGame) {
+        case gameType.maxiYatzy:
+        case gameType.maxiYatzyTypDown:
+            return 'bonusScore_maxiYatzy';
+        case gameType.yatzy:
+            return 'bonusScore_yatzy';
+    }
+}
+
+const bonusScoreStorage = (key: string): itemStorage<number> => {
+    const storage = new MMKV()
+    return {
+        save: (value: number) => storage.set(key, value),
+        get: () => storage.getNumber(key),
+        addListener: (onValueChanged: (key: string) => void): storageListener => {
+            let addedListener = storage.addOnValueChangedListener(onValueChanged)
+            return {
+                remove: () => {
+                    addedListener.remove()
+                }
+            }
+        }
+    }
+}
+
+export { bonusScoreStorage, bonusScoreKey };

--- a/src/utils/polyfills/backHandler.ts
+++ b/src/utils/polyfills/backHandler.ts
@@ -1,0 +1,31 @@
+import { BackHandler } from 'react-native';
+
+type BackPressHandler = () => boolean | null | undefined;
+type BackPressSubscription = { remove: () => void };
+
+const patched = BackHandler as unknown as {
+    addEventListener: (eventName: string, handler: BackPressHandler) => BackPressSubscription;
+    removeEventListener?: (eventName: string, handler: BackPressHandler) => void;
+    __removeEventListenerPolyfilled?: boolean;
+};
+
+if (!patched.__removeEventListenerPolyfilled && typeof patched.removeEventListener !== 'function') {
+    const subscriptions = new Map<BackPressHandler, BackPressSubscription>();
+    const originalAdd = patched.addEventListener.bind(BackHandler);
+
+    patched.addEventListener = (eventName, handler) => {
+        const subscription = originalAdd(eventName, handler);
+        subscriptions.set(handler, subscription);
+        return subscription;
+    };
+
+    patched.removeEventListener = (_eventName, handler) => {
+        const subscription = subscriptions.get(handler);
+        if (subscription) {
+            subscription.remove();
+            subscriptions.delete(handler);
+        }
+    };
+
+    patched.__removeEventListenerPolyfilled = true;
+}


### PR DESCRIPTION
## Summary

- New Settings entry to configure the Yatzy bonus score, with one input per game type (Maxi Yatzy and Yatzy). Persisted in MMKV via a new `itemStorage<number>` factory and read at game-creation time. Default for both game types is **50**; the bonus *limit* (63 / 75) is unchanged.
- Polyfills `BackHandler.removeEventListener` for RN 0.77, restoring the contract that `react-native-modal` 13.x still relies on. Fixes a latent runtime crash on modal teardown and unblocks 8 pre-existing test failures across `App`, `YatzyScreen`, `scoreModal`, and `addPlayerModal` suites.

## Files changed

- `src/utils/helpers/Storage/bonus/bonusScoreStorage.ts` (new) — MMKV-backed `itemStorage<number>` factory + `bonusScoreKey(gameType)` helper.
- `src/utils/helpers/Game/gameHelper.ts` — `getBonusScore` reads from storage; default `50`.
- `src/components/settings/bonusScoreSettings.tsx` (new) — two number inputs, persisted on `onEndEditing` / `onSubmitEditing`, invalid input snaps back.
- `src/components/settings/settingsModal.tsx` — renders the new section under `<LanguageSettings />`.
- `language/json/{en,se}/translation.json` — `settings.bonusScoreSettings` keys.
- `src/utils/polyfills/backHandler.ts` (new) — re-implements `BackHandler.removeEventListener` on top of the new subscription API. Imported from `index.js` and `jest.setup.js`.
- `src/utils/helpers/Game/__tests__/gameHelper.test.ts` — bonus assertions updated 100 → 50.

## Note on default change

This branch changes the Maxi Yatzy default bonus from the previous hardcoded **100** to **50**, per the requested spec. Existing users will see a lower bonus on their first launch unless they set a value in Settings.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test` — 13 / 13 suites, 37 / 37 tests passing (was 9 / 13, 29 / 37 on `main`).
- [ ] Smoke test — `smoke-test` label applied; will run on the PR's head ref.
- [ ] Manual UI on Android: open Settings → see "Bonus score" section with two inputs prefilled at 50; change Maxi Yatzy to e.g. 80, dismiss keyboard, reopen Settings → still 80; start a Maxi Yatzy game, fill the upper section past 75 → bonus row shows 80; restart the app → values persist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GALLdVnouxNW48vfLF9yKq)_